### PR TITLE
Multiple frontier inputs

### DIFF
--- a/src/sfma/models/utils.py
+++ b/src/sfma/models/utils.py
@@ -8,8 +8,6 @@ from anml.parameter.utils import combine_constraints
 
 
 def build_linear_constraint(constraints: List[Tuple[np.ndarray, np.ndarray, np.ndarray]]):
-    if len(constraints) == 1:
-        mats, lbs, ubs = constraints[0]
     mats, lbs, ubs = zip(*constraints)
     C, c_lb, c_ub = combine_constraints(mats, lbs, ubs)
     if np.count_nonzero(C) == 0:


### PR DESCRIPTION
Allows for multiple frontier inputs, including multiple 1D splines.

- Created a new `InputVar` object that collects all the information about spline and derivative constraint information per covariate.
- Constraints already were in block diagonal form, so that's taken care of.
- If we want a variable to just be linear, we can do `knots_num = 2` and `degree = 1`.